### PR TITLE
SCR-30 EmailSender 리팩토링 및 테스트 코드 작성

### DIFF
--- a/src/main/java/com/team17/preProject/exception/businessLogic/ExceptionCode.java
+++ b/src/main/java/com/team17/preProject/exception/businessLogic/ExceptionCode.java
@@ -13,6 +13,7 @@ public enum ExceptionCode {
     ALREADY_VOTE_GOOD(400, "Already vote good"),
     ALREADY_VOTE_BAD(400, "Already vote bad"),
     FAIL_SEND_EMAIL(300, "이메일 주소가 잘못되었거나 서버에서 메일을 보내지 못했습니다."),
+    FAIL_SEND_EMAIL_BY_SERVER(500, "서버에서 이메일을 전송하지 못했습니다."),
     NOT_VERIFIED_ANSWER_OF_QUESTION(400, "해당 질문의 답변이 아닙니다."),
     ALREADY_EXIST_BEST_ANSWER(400, "Already exist best answer"),
     MEMBER_NOT_MATCHED(400, "요청한 회원 식별자와 로그인 유저의 정보가 일치하지 않습니다."),

--- a/src/main/java/com/team17/preProject/helper/email/EmailSendable.java
+++ b/src/main/java/com/team17/preProject/helper/email/EmailSendable.java
@@ -5,5 +5,6 @@ import org.springframework.stereotype.Component;
 @Component
 public interface EmailSendable {
 
+    void send(String to, String subject, String message) throws InterruptedException;
     void send(String[] to, String subject, String Message) throws InterruptedException;
 }

--- a/src/main/java/com/team17/preProject/helper/email/SimpleEmailSender.java
+++ b/src/main/java/com/team17/preProject/helper/email/SimpleEmailSender.java
@@ -10,6 +10,11 @@ public class SimpleEmailSender implements EmailSendable{
     private final JavaMailSender javaMailSender;
 
     @Override
+    public void send(String to, String subject, String message) throws InterruptedException {
+        send(new String[]{to}, subject, message);
+    }
+
+    @Override
     public void send(String[] to, String subject, String message) throws InterruptedException {
         SimpleMailMessage mailMessage = new SimpleMailMessage();
         mailMessage.setTo(to);

--- a/src/main/java/com/team17/preProject/helper/email/password/TemporaryPasswordSender.java
+++ b/src/main/java/com/team17/preProject/helper/email/password/TemporaryPasswordSender.java
@@ -1,0 +1,28 @@
+package com.team17.preProject.helper.email.password;
+
+import com.team17.preProject.exception.businessLogic.BusinessLogicException;
+import com.team17.preProject.exception.businessLogic.ExceptionCode;
+import com.team17.preProject.helper.email.EmailSendable;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class TemporaryPasswordSender {
+
+    private static final String EMAIL_TITLE = "TEAM17 StackOverflow 클론 비밀번호 변경되었습니다";
+    private static final String EMAIL_CONTENT_FORM =
+            "당신의 비밀번호는 %s로 변경되었습니다.\n" +
+            "페이지로 가서 비밀번호를 변경해주세요.";
+
+    private final EmailSendable emailSender;
+
+    public void send(String email, String temporaryPassword) {
+        try {
+            String content  = String.format(EMAIL_CONTENT_FORM, temporaryPassword);
+            emailSender.send(email, EMAIL_TITLE, content);
+        } catch (InterruptedException e) {
+            throw new BusinessLogicException(ExceptionCode.FAIL_SEND_EMAIL_BY_SERVER);
+        }
+    }
+}

--- a/src/main/java/com/team17/preProject/helper/email/password/TemporaryPasswordSender.java
+++ b/src/main/java/com/team17/preProject/helper/email/password/TemporaryPasswordSender.java
@@ -21,7 +21,7 @@ public class TemporaryPasswordSender {
         try {
             String content  = String.format(EMAIL_CONTENT_FORM, temporaryPassword);
             emailSender.send(email, EMAIL_TITLE, content);
-        } catch (InterruptedException e) {
+        } catch (Exception e) {
             throw new BusinessLogicException(ExceptionCode.FAIL_SEND_EMAIL_BY_SERVER);
         }
     }

--- a/src/test/java/com/team17/preProject/helper/email/password/TemporaryPasswordSenderTest.java
+++ b/src/test/java/com/team17/preProject/helper/email/password/TemporaryPasswordSenderTest.java
@@ -4,9 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.when;
 
 import com.team17.preProject.exception.businessLogic.BusinessLogicException;
 import com.team17.preProject.helper.email.EmailSendable;

--- a/src/test/java/com/team17/preProject/helper/email/password/TemporaryPasswordSenderTest.java
+++ b/src/test/java/com/team17/preProject/helper/email/password/TemporaryPasswordSenderTest.java
@@ -1,0 +1,39 @@
+package com.team17.preProject.helper.email.password;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+
+import com.team17.preProject.exception.businessLogic.BusinessLogicException;
+import com.team17.preProject.helper.email.EmailSendable;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@SpringBootTest(classes = {TemporaryPasswordSender.class})
+public class TemporaryPasswordSenderTest {
+
+    @Autowired private TemporaryPasswordSender temporaryPasswordSender;
+    @MockBean private EmailSendable emailSendable;
+
+    @Test
+    void sendTest() {
+        assertDoesNotThrow(() -> temporaryPasswordSender.send("email", "abcd"));
+    }
+
+    @Test
+    void sendTest_whenSendingEmailFail() throws InterruptedException{
+        doThrow(IllegalArgumentException.class).when(emailSendable)
+                .send(anyString(), anyString(), anyString());
+
+        Exception result = assertThrows(BusinessLogicException.class,
+                () -> temporaryPasswordSender.send("email", "abcd"));
+        assertThat(result.getMessage()).isEqualTo("서버에서 이메일을 전송하지 못했습니다.");
+    }
+
+}


### PR DESCRIPTION
- 임시 비밀번호 전송을 담당하는 Class 생성 (TemporaryPasswordSender)
  - 기존 MemberService에서 전송 메일 정보를 가지고 있었는데, 이는 역할이 과중하게 있다고 판단하여 새 Class를 생성
  - MemberService Refactoring시에 적용 예정
- 안 쓰일 Class는 MemverService 리팩토링 시에 변경 예정