### PR TITLE
SCR-23 QuestionService 유닛 테스트 작성

### DIFF
--- a/src/test/java/com/team17/preProject/domain/answer/mapper/AnswerMapperTest.java
+++ b/src/test/java/com/team17/preProject/domain/answer/mapper/AnswerMapperTest.java
@@ -22,7 +22,7 @@ public class AnswerMapperTest {
     private AnswerMapper answerMapper;
     private static final Answer MOCK_ANSWER = AnswerStub.getEntity();
     static {
-        MOCK_ANSWER.setQuestion(QuestionStub.getEntity());
+        MOCK_ANSWER.setQuestion(QuestionStub.getChangeableEntity());
         MOCK_ANSWER.getQuestion().setMember(MemberStub.getChangeableEntity());
         MOCK_ANSWER.setMember(MemberStub.getChangeableEntity());
     }

--- a/src/test/java/com/team17/preProject/domain/follow/mapper/FollowAnswerMapperTest.java
+++ b/src/test/java/com/team17/preProject/domain/follow/mapper/FollowAnswerMapperTest.java
@@ -26,7 +26,7 @@ public class FollowAnswerMapperTest {
     private  FollowAnswerMapper mapper;
     private static final FollowAnswer MOCK_ENTITY = new FollowAnswer();
     private static final Answer MOCK_ANSWER = AnswerStub.getEntity();
-    private static final Question MOCK_QUESTION = QuestionStub.getEntity();
+    private static final Question MOCK_QUESTION = QuestionStub.getChangeableEntity();
     static {
         MOCK_QUESTION.setMember(MemberStub.getChangeableEntity());
         MOCK_ANSWER.setQuestion(MOCK_QUESTION);

--- a/src/test/java/com/team17/preProject/domain/follow/mapper/FollowQuestionMapperTest.java
+++ b/src/test/java/com/team17/preProject/domain/follow/mapper/FollowQuestionMapperTest.java
@@ -24,7 +24,7 @@ public class FollowQuestionMapperTest {
     private FollowQuestionMapper mapper;
 
     private static final FollowQuestion MOCK_ENTITY = new FollowQuestion();
-    private static final Question MOCK_QUESTION = QuestionStub.getEntity();
+    private static final Question MOCK_QUESTION = QuestionStub.getChangeableEntity();
     static {
         MOCK_ENTITY.setMember(MemberStub.getChangeableEntity());
         MOCK_QUESTION.setMember(MemberStub.getChangeableEntity());

--- a/src/test/java/com/team17/preProject/domain/question/service/QuestionServiceTest.java
+++ b/src/test/java/com/team17/preProject/domain/question/service/QuestionServiceTest.java
@@ -2,12 +2,15 @@ package com.team17.preProject.domain.question.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
+import com.team17.preProject.domain.member.entity.Member;
 import com.team17.preProject.domain.member.service.MemberService;
 import com.team17.preProject.domain.question.entity.Question;
 import com.team17.preProject.domain.question.repository.QuestionRepository;
 import com.team17.preProject.exception.businessLogic.BusinessLogicException;
+import com.team17.preProject.helper.stub.MemberStub;
 import com.team17.preProject.helper.stub.QuestionStub;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -45,5 +48,20 @@ public class QuestionServiceTest {
         Exception result = assertThrows(BusinessLogicException.class,
                 () -> questionService.findQuestion(questionId));
         assertThat(result.getMessage()).isEqualTo("Question not found");
+    }
+
+    @Test
+    void createQuestionTest() {
+        Question question = QuestionStub.getChangeableEntity();
+        Member memberInfo = Member.builder().memberId(1L).build();
+        question.setMember(memberInfo);
+        Member findMember = MemberStub.ENTITY;
+        given(memberService.findMember(memberInfo.getMemberId())).willReturn(findMember);
+        given(repository.save(any())).willReturn(question);
+
+        Question result = questionService.createQuestion(question);
+
+        assertThat(result).usingRecursiveComparison().isEqualTo(question);
+        assertThat(result.getMember()).isEqualTo(findMember);
     }
 }

--- a/src/test/java/com/team17/preProject/domain/question/service/QuestionServiceTest.java
+++ b/src/test/java/com/team17/preProject/domain/question/service/QuestionServiceTest.java
@@ -64,4 +64,19 @@ public class QuestionServiceTest {
         assertThat(result).usingRecursiveComparison().isEqualTo(question);
         assertThat(result.getMember()).isEqualTo(findMember);
     }
+
+    @Test
+    void updateQuestionTest() {
+        // Question Builder 패턴 구현 후 테스트 구현 예정
+    }
+
+    @Test
+    void updateQuestionTest_whenQuestionDoesNotExist() {
+        Question questionStub = QUESTION_STUB;
+        given(repository.findById(questionStub.getQuestionId())).willReturn(Optional.empty());
+
+        Exception result = assertThrows(BusinessLogicException.class,
+                () -> questionService.updateQuestion(questionStub));
+        assertThat(result.getMessage()).isEqualTo("Question not found");
+    }
 }

--- a/src/test/java/com/team17/preProject/domain/question/service/QuestionServiceTest.java
+++ b/src/test/java/com/team17/preProject/domain/question/service/QuestionServiceTest.java
@@ -1,6 +1,7 @@
 package com.team17.preProject.domain.question.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -77,6 +78,23 @@ public class QuestionServiceTest {
 
         Exception result = assertThrows(BusinessLogicException.class,
                 () -> questionService.updateQuestion(questionStub));
+        assertThat(result.getMessage()).isEqualTo("Question not found");
+    }
+
+    @Test
+    void deleteQuestionTest() {
+        Question questionStub = QUESTION_STUB;
+        given(repository.findById(questionStub.getQuestionId())).willReturn(Optional.of(questionStub));
+
+        assertDoesNotThrow(() -> questionService.deleteQuestion(questionStub.getQuestionId()));
+    }
+
+    @Test
+    void deleteQuestionTest_whenQuestionNotExist() {
+        given(repository.findById(any())).willReturn(Optional.empty());
+
+        Exception result = assertThrows(BusinessLogicException.class,
+                () -> questionService.deleteQuestion(1L));
         assertThat(result.getMessage()).isEqualTo("Question not found");
     }
 }

--- a/src/test/java/com/team17/preProject/domain/question/service/QuestionServiceTest.java
+++ b/src/test/java/com/team17/preProject/domain/question/service/QuestionServiceTest.java
@@ -1,0 +1,49 @@
+package com.team17.preProject.domain.question.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+
+import com.team17.preProject.domain.member.service.MemberService;
+import com.team17.preProject.domain.question.entity.Question;
+import com.team17.preProject.domain.question.repository.QuestionRepository;
+import com.team17.preProject.exception.businessLogic.BusinessLogicException;
+import com.team17.preProject.helper.stub.QuestionStub;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import java.util.Optional;
+
+@SpringBootTest(classes = {QuestionServiceImpl.class})
+public class QuestionServiceTest {
+
+    @Autowired private QuestionService questionService;
+    @MockBean private QuestionRepository repository;
+    @MockBean private MemberService memberService;
+
+    private static final Question QUESTION_STUB = QuestionStub.ENTITY;
+
+    @Test
+    void findQuestionTest() {
+        Question questionStub = QuestionStub.getChangeableEntity();
+        long questionId = questionStub.getQuestionId();
+        long beforeView = questionStub.getView();
+        given(repository.findById(questionId)).willReturn(Optional.of(questionStub));
+
+        Question result = questionService.findQuestion(questionId);
+
+        assertThat(result).usingRecursiveComparison().isEqualTo(questionStub);
+        assertThat(result.getView()).isEqualTo(beforeView + 1);
+    }
+
+    @Test
+    void findQuestionTest_whenQuestionNotExist() {
+        long questionId = 1L;
+        given(repository.findById(questionId)).willReturn(Optional.empty());
+
+        Exception result = assertThrows(BusinessLogicException.class,
+                () -> questionService.findQuestion(questionId));
+        assertThat(result.getMessage()).isEqualTo("Question not found");
+    }
+}

--- a/src/test/java/com/team17/preProject/helper/stub/QuestionStub.java
+++ b/src/test/java/com/team17/preProject/helper/stub/QuestionStub.java
@@ -99,7 +99,7 @@ public class QuestionStub {
     private static final long MOCK_VIEW = 100L;
     private static final long MOCK_VOTE = 10L;
 
-    public static Question getEntity() {
+    public static Question getChangeableEntity() {
         Question mockQuestion = new Question();
         mockQuestion.setQuestionId(MOCK_QUESTION_ID);
         mockQuestion.setTitle(MOCK_TITLE);


### PR DESCRIPTION
- QuestionService의 public method 별 유닛 테스트 작성 실시
  - findQuestionsByKeyword(), findQuestionsByMemberId() 는 값을 전달하는 역할만을 하므로 따로 유닛테스트를 만들지 않음
  - updateQuestionTest()는 추후 Builder 패턴 구현 후 작성 예정

- 유닛 테스트 전원 통과 확인 완료.